### PR TITLE
add jinja cached_client patch

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -109,6 +109,10 @@ class SaltCacheLoader(BaseLoader):
         ):
             attr = "_cached_pillar_client" if self.pillar_rend else "_cached_client"
             cached_client = getattr(self, attr, None)
+            if cached_client is not None:
+                if cached_client.opts['cachedir'] != self.opts['cachedir']:
+                    self.shutdown()
+                    cached_client = None
             if (
                 cached_client is None
                 or not hasattr(cached_client, "opts")


### PR DESCRIPTION


### What does this PR do?

Fix the `jinja2.exceptions.TemplateNotFound: zookeeper/map.jinja` error when using `salt-ssh` to apply states on `v3003` - `v3005` - sounds like it should be fixed upstream in `v3006` via https://github.com/saltstack/salt/pull/63184

### What issues does this PR fix or reference?

Fixes:
* https://github.com/saltstack/salt/issues/60620#issuecomment-908907182
* https://github.com/saltstack/salt/issues/61174
