### PR TITLE
import typing_extensions for compatibility with hosts on python <3.8

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -33,6 +33,7 @@ import yaml
 has_immutables = False
 try:
     import immutables
+    import typing_extensions
 
     has_immutables = True
 except ImportError:
@@ -435,6 +436,7 @@ def get_tops(extra_mods="", so_mods=""):
     mods.append(contextvars)
     if has_immutables:
         mods.append(immutables)
+        mods.append(typing_extensions)
     for mod in mods:
         if mod:
             log.debug('Adding module to the tops: "%s"', mod.__name__)


### PR DESCRIPTION
### What does this PR do?

Fixes `state.apply` from newer python/salt versions against older hosts running Python 3.7.

confirmed working from my mac to both deb10 (snuba-transactions-tiger) and deb11 (access-logs) targets

### What issues does this PR fix or reference?
Fixes:

https://github.com/saltstack/salt/issues/59942
https://github.com/saltstack/salt/pull/62234

### Previous Behavior

```
salt-ssh "snuba-transactions-tiger-1-1" state.apply base test=True

...

ModuleNotFoundError: No module named 'typing_extensions'

```

### New Behavior

```
salt-ssh "snuba-transactions-tiger-1-1" state.apply base test=True

...

Summary for snuba-transactions-tiger-1-1
-------------
Succeeded: 65
Failed:     0
-------------
Total states run:     65
Total run time:    6.722 s

```