### PR TITLE
Disable the setuptools user warning "Setuptools is replacing distutils."

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -69,6 +69,14 @@ warnings.filterwarnings(
     append=True,
 )
 
+# https://github.com/saltstack/salt/pull/62863
+warnings.filterwarnings(
+    "ignore",
+    message="Setuptools is replacing distutils.",
+    category=UserWarning,
+    module="_distutils_hack",
+)
+
 
 def __define_global_system_encoding_variable__():
     import sys

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ The setup script for salt
 """
 
 # pylint: disable=file-perms,resource-leakage
+import setuptools # isort:skip
+
 import contextlib
 import distutils.dist
 import glob


### PR DESCRIPTION
https://github.com/saltstack/salt/pull/62863

### What does this PR do?

### What issues does this PR fix or reference?

Fixes: 

```
/Users/mwarkentin/repos/sentry/ops/salt/.venv/lib/python3.8/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.
  warnings.warn("Setuptools is replacing distutils.")
```

Taken from upstream: https://github.com/saltstack/salt/pull/62863